### PR TITLE
Added derived Debug traits to all structs. Changed the README and doc…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mrt-rs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Christian Veenman <chris_veenman@hotmail.com>"]
 edition = '2018'
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -3,43 +3,8 @@
 
 A library for parsing Multi-Threaded Routing Toolkit (MRT) formatted streams in Rust.
 
-## Example
-In this example we read an gzip MRT archive from a file and parse it. Note that the MRTReader works with any object that implements the [Read](https://doc.rust-lang.org/std/io/trait.Read.html) trait.
-```
-use std::fs::File;
-use std::io::Cursor;
-use std::io::Read;
-use mrt_rs::MRTReader;
-use mrt_rs::MRTRecord;
-use libflate::gzip::Decoder;
-
-fn main() {
-     // Open an gzip archive that contains a MRT-formatted file.
-     let file = File::open("res/updates.20190101.0000.gz").unwrap();
-
-     // Decode the GZIP stream
-     let mut decoder = Decoder::new(file).unwrap();
-
-     // Read the entire contents of the File in a buffer.
-     let mut buffer: Vec<u8> = vec![];
-     decoder.read_to_end(&mut buffer).unwrap();
-     let length = buffer.len() as u64;
-
-     // Create a new MRTReader with a Cursor such that we can keep track of the position.
-     let mut reader = MRTReader {
-         stream: Cursor::new(buffer),
-     };
-
-    // Keep reading entries till the end of the file has been reached.
-     // _ can be replaced with the MRT type contained in your MRT file.
-     while reader.stream.position() < length {
-        let result = reader.read();
-       match &result.unwrap() {
-            MRTRecord::BGP4MP(_x) => continue,
-        }
-    }
-}
-```
+## Examples & Documentation
+For examples and documentation look [here](https://docs.rs/mrt-rs/0.1.0/mrt_rs/).
 
 ## Supported types
 All MRT record types (including deprecated ones) that are mentioned in [RFC6396](https://tools.ietf.org/html/rfc6396) are supported except for RIB_GENERIC (sub-type of TABLE_DUMP_V2) and the BGP4MP_ENTRY (sub-type of BGP4MP). It should be noted however that only BGP4MP and TABLE_DUMP_V2 messages currently contain tests. This is due to the fact that I do not have MRT-formatted streams for other protocols.
@@ -66,6 +31,6 @@ All MRT record types (including deprecated ones) that are mentioned in [RFC6396]
 - OSPFv3
 - OSPFv3_ET
 
-## Help required
-Do you have MRT files for MRT types that are currently not tested? Please let me know so I can add new tests for these types as well.
+## Help needed!
+*Do you have MRT files for MRT types that are currently not tested?* Please let me know so I can add new tests for these types as well.
 Any bug reports or requests for additional features are always welcome and can be submitted at the [Issue Tracker](https://github.com/DevQps/mrt-rs).

--- a/src/records/bgp4mp.rs
+++ b/src/records/bgp4mp.rs
@@ -1,5 +1,4 @@
 use byteorder::{BigEndian, ReadBytesExt};
-use std::fmt;
 use std::io::{Error, ErrorKind, Read};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -9,9 +8,9 @@ use crate::AFI;
 ///
 /// The BGP4MP enum represents all possible subtypes of the BGP4MP record type.
 ///
+#[derive(Debug)]
 #[allow(non_camel_case_types)]
 pub enum BGP4MP {
-
     /// Represents a state change of the BGP collector using 16 bit ASN.
     STATE_CHANGE(BGP4MP_STATE_CHANGE),
 
@@ -38,8 +37,7 @@ pub enum BGP4MP {
 }
 
 ///
-/// # Summary
-/// BGP4MP Message which is received when the BGP collector changes states.
+/// Represents a state change in the BGP Finite State Machine (FSM).
 ///
 /// 1 Idle
 /// 2 Connect
@@ -47,20 +45,34 @@ pub enum BGP4MP {
 /// 4 OpenSent
 /// 5 OpenConfirm
 /// 6 Established
+/// More information can found in [RFC4271](https://tools.ietf.org/html/rfc4271#section-8).
 ///
+#[derive(Debug)]
 #[allow(non_camel_case_types)]
 pub struct BGP4MP_STATE_CHANGE {
+    /// The peer ASN from which the BGP message has been received.
     pub peer_as: u16,
+
+    /// The ASN of the AS that received this BGP message.
     pub local_as: u16,
+
+    /// The interface identifier to which this message applies.
     pub interface: u16,
+
+    /// The peer IP address address from which the BGP message has been received.
     pub peer_address: IpAddr,
+
+    /// The IP address of the AS that received this BGP message.
     pub local_address: IpAddr,
+
+    /// The old state of the BGP collector.
     pub old_state: u16,
+
+    /// The new state of the BGP collector.
     pub new_state: u16,
 }
 
 impl BGP4MP_STATE_CHANGE {
-
     fn parse(stream: &mut Read) -> Result<BGP4MP_STATE_CHANGE, Error> {
         let peer_as = stream.read_u16::<BigEndian>()?;
         let local_as = stream.read_u16::<BigEndian>()?;
@@ -89,18 +101,31 @@ impl BGP4MP_STATE_CHANGE {
     }
 }
 
+/// Represents a BGP message (UPDATE, OPEN, NOTIFICATION and KEEPALIVE) using 16bit ASN.
+#[derive(Debug)]
 #[allow(non_camel_case_types)]
 pub struct BGP4MP_MESSAGE {
+    /// The peer ASN from which the BGP message has been received.
     pub peer_as: u16,
+
+    /// The ASN of the AS that received this BGP message.
     pub local_as: u16,
+
+    /// The interface identifier to which this message applies.
     pub interface: u16,
+
+    /// The peer IP address address from which the BGP message has been received.
     pub peer_address: IpAddr,
+
+    /// The IP address of the AS that received this BGP message.
     pub local_address: IpAddr,
+
+    /// The message that has been received.
     pub message: Vec<u8>,
 }
 
 impl BGP4MP_MESSAGE {
-    pub fn parse(header: MRTHeader, stream: &mut Read) -> Result<BGP4MP_MESSAGE, Error> {
+    fn parse(header: MRTHeader, stream: &mut Read) -> Result<BGP4MP_MESSAGE, Error> {
         let peer_as = stream.read_u16::<BigEndian>()?;
         let local_as = stream.read_u16::<BigEndian>()?;
         let interface = stream.read_u16::<BigEndian>()?;
@@ -129,42 +154,31 @@ impl BGP4MP_MESSAGE {
     }
 }
 
-impl fmt::Display for BGP4MP_MESSAGE {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "(Peer AS: {}, Local AS: {}, Interface: {}, Peer IP Address: {}, Local IP Address: {}, Size: {})",
-               self.peer_as,
-               self.local_as,
-               self.interface,
-               self.peer_address,
-               self.local_address,
-               self.message.len())
-    }
-}
-
+/// Represents a BGP message (UPDATE, OPEN, NOTIFICATION and KEEPALIVE) using 32bit ASN.
+#[derive(Debug)]
 #[allow(non_camel_case_types)]
 pub struct BGP4MP_MESSAGE_AS4 {
+    /// The peer ASN from which the BGP message has been received.
     pub peer_as: u32,
+
+    /// The ASN of the AS that received this BGP message.
     pub local_as: u32,
+
+    /// The interface identifier to which this message applies.
     pub interface: u16,
+
+    /// The peer IP address address from which the BGP message has been received.
     pub peer_address: IpAddr,
+
+    /// The IP address of the AS that received this BGP message.
     pub local_address: IpAddr,
+
+    /// The message that has been received.
     pub message: Vec<u8>,
 }
 
-impl fmt::Display for BGP4MP_MESSAGE_AS4 {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "(Peer AS: {}, Local AS: {}, Interface: {}, Peer IP Address: {}, Local IP Address: {}, Size: {})",
-               self.peer_as,
-               self.local_as,
-               self.interface,
-               self.peer_address,
-               self.local_address,
-               self.message.len())
-    }
-}
-
 impl BGP4MP_MESSAGE_AS4 {
-    pub fn parse(header: MRTHeader, stream: &mut Read) -> Result<BGP4MP_MESSAGE_AS4, Error> {
+    fn parse(header: MRTHeader, stream: &mut Read) -> Result<BGP4MP_MESSAGE_AS4, Error> {
         let peer_as = stream.read_u32::<BigEndian>()?;
         let local_as = stream.read_u32::<BigEndian>()?;
         let interface = stream.read_u16::<BigEndian>()?;
@@ -193,19 +207,44 @@ impl BGP4MP_MESSAGE_AS4 {
     }
 }
 
+///
+/// Represents a state change in the BGP Finite State Machine (FSM).
+///
+/// 1 Idle
+/// 2 Connect
+/// 3 Active
+/// 4 OpenSent
+/// 5 OpenConfirm
+/// 6 Established
+/// More information can found in [RFC4271](https://tools.ietf.org/html/rfc4271#section-8).
+///
+#[derive(Debug)]
 #[allow(non_camel_case_types)]
 pub struct BGP4MP_STATE_CHANGE_AS4 {
+    /// The peer ASN from which the BGP message has been received.
     pub peer_as: u32,
+
+    /// The ASN of the AS that received this BGP message.
     pub local_as: u32,
+
+    /// The interface identifier to which this message applies.
     pub interface: u16,
+
+    /// The peer IP address address from which the BGP message has been received.
     pub peer_address: IpAddr,
+
+    /// The IP address of the AS that received this BGP message.
     pub local_address: IpAddr,
+
+    /// The old state of the BGP collector.
     pub old_state: u16,
+
+    /// The new state of the BGP collector.
     pub new_state: u16,
 }
 
 impl BGP4MP_STATE_CHANGE_AS4 {
-    pub fn parse(stream: &mut Read) -> Result<BGP4MP_STATE_CHANGE_AS4, Error> {
+    fn parse(stream: &mut Read) -> Result<BGP4MP_STATE_CHANGE_AS4, Error> {
         let peer_as = stream.read_u32::<BigEndian>()?;
         let local_as = stream.read_u32::<BigEndian>()?;
         let interface = stream.read_u16::<BigEndian>()?;
@@ -233,14 +272,19 @@ impl BGP4MP_STATE_CHANGE_AS4 {
     }
 }
 
+/// Deprecated: Used to record BGP4MP messages in a file.
+#[derive(Debug)]
 #[allow(non_camel_case_types)]
 pub struct BGP4MP_SNAPSHOT {
+    /// The associated view number.
     pub view_number: u16,
+
+    /// The NULL-terminated filename of the file where BGP4MP_ENTRY records are recorded.
     pub filename: Vec<u8>,
 }
 
 impl BGP4MP_SNAPSHOT {
-    pub fn parse(stream: &mut Read) -> Result<BGP4MP_SNAPSHOT, Error> {
+    fn parse(stream: &mut Read) -> Result<BGP4MP_SNAPSHOT, Error> {
         let view_number = stream.read_u16::<BigEndian>()?;
         let mut filename = Vec::new();
 
@@ -258,7 +302,6 @@ impl BGP4MP_SNAPSHOT {
 }
 
 impl BGP4MP {
-
     ///
     /// # Summary
     /// Used to parse sub-types of the BGP4MP MRT record type.
@@ -273,10 +316,11 @@ impl BGP4MP {
     /// # Safety
     /// This function does not make use of unsafe code.
     ///
-    pub fn parse(header: MRTHeader, stream: &mut Read) -> Result<BGP4MP, Error> {
-
-        debug_assert!(header.record_type == 16 || header.record_type == 17,
-                      "Invalid record type in MRTHeader, expected BGP4MP record type.");
+    pub(crate) fn parse(header: MRTHeader, stream: &mut Read) -> Result<BGP4MP, Error> {
+        debug_assert!(
+            header.record_type == 16 || header.record_type == 17,
+            "Invalid record type in MRTHeader, expected BGP4MP record type."
+        );
 
         match header.sub_type {
             0 => Ok(BGP4MP::STATE_CHANGE(BGP4MP_STATE_CHANGE::parse(stream)?)),

--- a/src/records/ospf.rs
+++ b/src/records/ospf.rs
@@ -6,6 +6,7 @@ use crate::MRTHeader;
 use crate::AFI;
 
 /// The OSPFv2 struct represents the data contained in an MRT record type of OSPFv2.
+#[derive(Debug)]
 pub struct OSPFv2 {
     /// The IPv4 address from which this message was received.
     pub remote: Ipv4Addr,
@@ -18,7 +19,6 @@ pub struct OSPFv2 {
 }
 
 impl OSPFv2 {
-
     ///
     /// # Summary
     /// Used to parse OSPFv2 MRT records.
@@ -49,14 +49,19 @@ impl OSPFv2 {
 }
 
 /// The OSPFv3 struct represents the data contained in an MRT record type of OSPFv3 and OSPFv3_ET.
+#[derive(Debug)]
 pub struct OSPFv3 {
+    /// The IP address of the router from which this message was received.
     pub remote: IpAddr,
+
+    /// The IP address of the interface at which this message was received.
     pub local: IpAddr,
+
+    /// The message that has been received.
     pub message: Vec<u8>,
 }
 
 impl OSPFv3 {
-
     ///
     /// # Summary
     /// Used to parse OSPFv3 MRT records.

--- a/src/records/rip.rs
+++ b/src/records/rip.rs
@@ -6,15 +6,19 @@ use crate::MRTHeader;
 use crate::AFI;
 
 /// The RIP struct represents the data contained in an MRT record type of RIP.
+#[derive(Debug)]
 pub struct RIP {
-    pub header: MRTHeader,
+    /// The IPv4 address of the router from which this message was received.
     pub remote: Ipv4Addr,
+
+    /// The IPv4 address of the interface at which this message was received.
     pub local: Ipv4Addr,
+
+    /// The message that has been received.
     pub message: Vec<u8>,
 }
 
 impl RIP {
-
     ///
     /// # Summary
     /// Used to parse RIP MRT records.
@@ -33,7 +37,6 @@ impl RIP {
         // The fixed size of the header consisting of two IPv4 addresses.
         let length = (header.length - 2 * AFI::IPV4.size()) as usize;
         let mut record = RIP {
-            header,
             remote: Ipv4Addr::from(stream.read_u32::<BigEndian>()?),
             local: Ipv4Addr::from(stream.read_u32::<BigEndian>()?),
             message: vec![0; length as usize],
@@ -46,15 +49,19 @@ impl RIP {
 }
 
 /// The RIP struct represents the data contained in an MRT record type of RIP.
+#[derive(Debug)]
 pub struct RIPNG {
-    pub header: MRTHeader,
+    /// The IPv6 address of the router from which this message was received.
     pub remote: Ipv6Addr,
+
+    /// The IPv6 address of the interface at which this message was received.
     pub local: Ipv6Addr,
+
+    /// The message that has been received.
     pub message: Vec<u8>,
 }
 
 impl RIPNG {
-
     ///
     /// # Summary
     /// Used to parse RIPNG MRT records.
@@ -73,7 +80,6 @@ impl RIPNG {
         // The fixed size of the header consisting of two IPv4 addresses.
         let length = (header.length - 2 * AFI::IPV6.size()) as usize;
         let mut record = RIPNG {
-            header,
             remote: Ipv6Addr::from(stream.read_u128::<BigEndian>()?),
             local: Ipv6Addr::from(stream.read_u128::<BigEndian>()?),
             message: vec![0; length as usize],

--- a/tests/ripe.rs
+++ b/tests/ripe.rs
@@ -1,5 +1,7 @@
-use mrt_rs::MRTReader;
 use libflate::gzip::Decoder;
+use mrt_rs::MRTReader;
+use mrt_rs::MRTRecord;
+use mrt_rs::BGP4MP;
 use std::fs::File;
 use std::io::Cursor;
 use std::io::Read;
@@ -45,6 +47,11 @@ fn parse(readable: &mut Read) {
     while reader.stream.position() < length {
         let result = reader.read();
         match &result.unwrap() {
+            MRTRecord::BGP4MP(x) => match x {
+                BGP4MP::MESSAGE(y) => println!("{:?}", y),
+                BGP4MP::MESSAGE_AS4(y) => println!("{:?}", y),
+                _ => continue,
+            },
             _ => continue,
         }
     }


### PR DESCRIPTION
# Changes
Multiple changes were done:

1. README was updated with an example showing how to parse BGP4MP messages.
2. lib.rs example was updated showing how to parse BGP4MP messages.
3. All structs have been documented and publicly exported.
4. ```#[derive(Debug)]``` has been added to all structs such that they can be displayed easily.